### PR TITLE
Resize buttons

### DIFF
--- a/app/templates/document-review.hbs
+++ b/app/templates/document-review.hbs
@@ -45,15 +45,15 @@
       </select>
     </AuFormRow>
     <AuFormRow>
-      <AuButtonGroup class="au-u-1-1 au-u-flex--no-wrap">
-        <AuButton @width="block" @skin="secondary">
+      <AuButtonGroup class="au-u-1-1 au-u-flex--between au-u-flex--no-wrap">
+        <AuButton class="au-u-1-3" @skin="secondary">
           <AuLink @route="document-upload">
             Terug
           </AuLink>
         </AuButton>
 
         <AuButton
-          @width="block"
+          class="au-u-1-3 au-u-flex--center"
           @disabled={{not this.document.documentType}}
           {{on "click" this.handleValidation}}
         >


### PR DESCRIPTION
# BNB-626

## What?
Redesigning the document-review route.

## Why?
In order to make the buttons more visually appealing.

## Screenshots

Before

<img width="1081" alt="image" src="https://github.com/lblod/frontend-validation-tool/assets/50323795/f484d678-83b2-4964-8bc3-76919adefd73">

After

<img width="1081" alt="image" src="https://github.com/lblod/frontend-validation-tool/assets/50323795/75909cb5-65d0-4ed0-a0d8-5bdc5c95e8bc">

For more information, please refer to the ticket [BNB-626](https://binnenland.atlassian.net/browse/BNB-626).