### PR TITLE
Validate generic data (custom SHACL shape)

### DIFF
--- a/app/controllers/document-review.ts
+++ b/app/controllers/document-review.ts
@@ -5,10 +5,18 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import type DocumentService from 'frontend-validation-tool/services/document';
 import { getDocumentTypes } from '@lblod/lib-decision-validation/dist/queries';
+import type { UploadFile } from 'ember-file-upload/upload-file';
 
 export default class DocumentReviewController extends Controller {
   @service declare document: DocumentService;
   @service declare router: RouterService;
+
+  @tracked selectOptions = getDocumentTypes();
+  @tracked uploadedFile: File | null = null;
+
+  @action onFinishUpload(uploadedFile: UploadFile) {
+    this.uploadedFile = uploadedFile.file;
+  }
 
   @action handleValidation() {
     this.router.transitionTo('validation-results', {
@@ -18,6 +26,4 @@ export default class DocumentReviewController extends Controller {
       },
     });
   }
-
-  @tracked selectOptions = getDocumentTypes();
 }

--- a/app/controllers/document-review.ts
+++ b/app/controllers/document-review.ts
@@ -15,7 +15,7 @@ export default class DocumentReviewController extends Controller {
   @tracked uploadedFile: File | null = null;
 
   @action onFinishUpload(uploadedFile: UploadFile) {
-    this.uploadedFile = uploadedFile.file;
+    this.document.customBlueprint = uploadedFile.file;
   }
 
   @action handleValidation() {

--- a/app/routes/validation-results.ts
+++ b/app/routes/validation-results.ts
@@ -29,14 +29,22 @@ export default class ValidationResultsRoute extends Route {
         this.document.isProcessingFile &&
         this.document.documentType &&
         !params['url']
-      ) {
+      )
         return;
-      }
+
+      if (
+        this.document.isProcessingFile &&
+        this.document.customBlueprint &&
+        !params['url']
+      )
+        return;
+
       this.document.isProcessingFile = false;
       if (!params['url']) {
         this.router.transitionTo('document-upload');
         return;
       }
+
       // Check if the document type is valid and if not, redirect to the document upload page
       if (
         !params['documentType'] &&

--- a/app/services/document.ts
+++ b/app/services/document.ts
@@ -117,18 +117,10 @@ export default class DocumentService extends Service {
     const html = await file.text();
     const document = await getPublicationFromFileContent(html);
     this.document = document;
-    this.documentType = await determineDocumentType(document);
 
-    if (this.documentType && this.documentType !== 'unknown document type') {
-      return true;
-    } else {
-      this.documentType = '';
-      this.toaster.error(
-        'Deze publicatie heeft geen documenttype',
-        'Kies een type uit de lijst',
-      );
-      return false;
-    }
+    const determinedType = await determineDocumentType(document);
+    this.documentType =
+      determinedType === 'unknown document type' ? '' : determinedType;
   }
 
   // Function to process a document URL (as entered by the user in route: document-upload)

--- a/app/services/document.ts
+++ b/app/services/document.ts
@@ -88,13 +88,13 @@ export default class DocumentService extends Service {
   }
 
   validateDocument = task({ drop: true }, async () => {
+    if (!this.isProcessingFile) {
+      this.document = await fetchDocument(this.documentURL, this.corsProxy);
+    }
+
     if (this.documentType) {
       const blueprint = await getBlueprintOfDocumentType(this.documentType);
       const example = await getExampleOfDocumentType(this.documentType);
-
-      if (!this.isProcessingFile) {
-        this.document = await fetchDocument(this.documentURL, this.corsProxy);
-      }
 
       const onProgress = (message: string) => {
         this.loadingStatus = `${message}`;

--- a/app/services/document.ts
+++ b/app/services/document.ts
@@ -20,6 +20,7 @@ export default class DocumentService extends Service {
   @tracked documentURL: string = '';
   @tracked documentType: string = '';
   @tracked documentFile: File | null = null;
+  @tracked customBlueprint: File | null = null;
   @tracked maturity: string = '';
   @tracked validatedDocument: any = [];
   @tracked isProcessingFile: boolean = false;

--- a/app/services/document.ts
+++ b/app/services/document.ts
@@ -158,10 +158,6 @@ export default class DocumentService extends Service {
       return true;
     } else {
       this.documentType = '';
-      this.toaster.error(
-        'Deze publicatie heeft geen documenttype',
-        'Kies een type uit de lijst',
-      );
       return false;
     }
   }

--- a/app/templates/document-review.hbs
+++ b/app/templates/document-review.hbs
@@ -25,12 +25,6 @@
         placeholder="Documenttype"
         class="au-c-input au-u-1-1"
       >
-        {{#unless this.document.documentType}}
-          <option value="" selected disabled hidden>
-            Selecteer een documenttype
-          </option>
-        {{/unless}}
-
         {{#each this.selectOptions as |documentType|}}
           {{#if (eq documentType.label this.document.documentType)}}
             <option value={{documentType.label}} selected>
@@ -42,6 +36,12 @@
             </option>
           {{/if}}
         {{/each}}
+
+        {{#if this.document.documentType}}
+          <option value="">Kies eigen blauwdruk ...</option>
+        {{else}}
+          <option value="" selected>Kies eigen blauwdruk ...</option>
+        {{/if}}
       </select>
     </AuFormRow>
 

--- a/app/templates/document-review.hbs
+++ b/app/templates/document-review.hbs
@@ -68,11 +68,14 @@
 
         <AuButton
           class="au-u-1-3 au-u-flex--center"
-          @disabled={{not this.document.documentType}}
+          @disabled={{and
+            (not this.document.documentType)
+            (not this.uploadedFile)
+          }}
           {{on "click" this.handleValidation}}
         >
           {{! TODO: Add functionality }}
-          Validatie Starten
+          Validatie starten
         </AuButton>
       </AuButtonGroup>
     </AuFormRow>

--- a/app/templates/document-review.hbs
+++ b/app/templates/document-review.hbs
@@ -70,7 +70,7 @@
           class="au-u-1-3 au-u-flex--center"
           @disabled={{and
             (not this.document.documentType)
-            (not this.uploadedFile)
+            (not this.document.customBlueprint)
           }}
           {{on "click" this.handleValidation}}
         >

--- a/app/templates/document-review.hbs
+++ b/app/templates/document-review.hbs
@@ -3,7 +3,7 @@
 <section data-test-document-review>
   <span class="au-u-text-center">
     <h2>Documenttype selecteren</h2>
-    <p class="au-u-margin-top-tiny">Hieronder kunt u de link naar het document
+    <p class="au-u-margin-top-tiny">
       Indien het automatisch toegewezen documenttype niet overeenkomt met uw
       verwachtingen, kunt u dit aanpassen door een andere keuze te maken
       hieronder.

--- a/app/templates/document-review.hbs
+++ b/app/templates/document-review.hbs
@@ -44,6 +44,20 @@
         {{/each}}
       </select>
     </AuFormRow>
+
+    {{#unless this.document.documentType}}
+      <AuFormRow>
+        <FileInput
+          class="au-u-1-1"
+          @accept={{".ttl"}}
+          @title={{"Upload een Turtle-bestand"}}
+          @helpTextDragDrop={{"Sleep het bestand naar hier om toe te voegen"}}
+          @helpTextFileNotSupported={{"Dit bestandstype wordt niet ondersteund"}}
+          @onFinishUpload={{this.onFinishUpload}}
+        />
+      </AuFormRow>
+    {{/unless}}
+
     <AuFormRow>
       <AuButtonGroup class="au-u-1-1 au-u-flex--between au-u-flex--no-wrap">
         <AuButton class="au-u-1-3" @skin="secondary">

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
-        "@lblod/lib-decision-validation": "^1.0.38",
+        "@lblod/lib-decision-validation": "^1.0.40-beta.0",
         "dayjs": "^1.11.11",
         "node-libs-browser": "^2.2.1",
         "pretty": "^2.0.0",
@@ -17966,9 +17966,9 @@
       }
     },
     "node_modules/@lblod/lib-decision-validation": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@lblod/lib-decision-validation/-/lib-decision-validation-1.0.38.tgz",
-      "integrity": "sha512-QnB2djyDkHZdD14ObCjfga3jQcRyw5mT9OSQaPa380OAQKB6nP/4+s1HiMpo47TzmOpy2pIoizk5DCnlB7tbdQ==",
+      "version": "1.0.40-beta.0",
+      "resolved": "https://registry.npmjs.org/@lblod/lib-decision-validation/-/lib-decision-validation-1.0.40-beta.0.tgz",
+      "integrity": "sha512-dNF4BmUsF6pFjOAou++fbe1Y0CuZV598O993FtcsPdzeDaSXyu+M+iNyOI5AYFEN1qcrYANGNMCirhFM9jAveA==",
       "dependencies": {
         "@comunica/actor-http-proxy": "^3.0.3",
         "@comunica/query-sparql": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "ember-file-upload": "^8.4.0"
   },
   "dependencies": {
-    "@lblod/lib-decision-validation": "^1.0.40-beta.0",
+    "@lblod/lib-decision-validation": "^1.0.42",
     "dayjs": "^1.11.11",
     "node-libs-browser": "^2.2.1",
     "pretty": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "ember-file-upload": "^8.4.0"
   },
   "dependencies": {
-    "@lblod/lib-decision-validation": "^1.0.38",
+    "@lblod/lib-decision-validation": "^1.0.40-beta.0",
     "dayjs": "^1.11.11",
     "node-libs-browser": "^2.2.1",
     "pretty": "^2.0.0",


### PR DESCRIPTION
BNB-771

Next to the "built-in" shacl shapes, users can now upload their own as a Turtle file. This enables validating any data against any shacl shapes document.