### PR TITLE
Feature/bnb 806 auto scroll to document part

### DIFF
--- a/app/components/class-collection.hbs
+++ b/app/components/class-collection.hbs
@@ -1,6 +1,25 @@
-<CustomAccordion data-test-class-collection @defaultOpen="true">
+<CustomAccordion
+  data-test-class-collection
+  @defaultOpen={{if (current-url-hash @validationId) true false}}
+  id="validationBlock-{{@validationId}}"
+>
   <:toolbar>
-    {{@collection.className}}
+    <span class="au-u-flex--vertical-center au-u-flex">
+      <p
+        class="au-u-margin-right-tiny au-u-margin-left-none au-u-margin-bottom-none"
+      >
+        <CopyToClipboard
+          @hideValue="true"
+          @icon="paperclip"
+          @value="{{concat
+            (current-url-without-hash)
+            '#validationBlock-'
+            @validationId
+          }}"
+        />
+        {{@collection.className}}
+      </p>
+    </span>
   </:toolbar>
   <:counts>{{@collection.count}}</:counts>
   <:content>
@@ -14,7 +33,10 @@
       </AuAlert>
     {{/if}}
     {{#each @collection.objects as |object index|}}
-      <RecursiveEntry @subject={{object}} @index={{index}} />
+      <RecursiveEntry
+        @subject={{object}}
+        @validationId={{join-with-dash @validationId index}}
+      />
     {{/each}}
   </:content>
 </CustomAccordion>

--- a/app/components/class-collection.hbs
+++ b/app/components/class-collection.hbs
@@ -33,10 +33,12 @@
       </AuAlert>
     {{/if}}
     {{#each @collection.objects as |object index|}}
-      <RecursiveEntry
-        @subject={{object}}
-        @validationId={{join-with-dash @validationId index}}
-      />
+      {{#let (add index 1) as |newIndex|}}
+        <RecursiveEntry
+          @subject={{object}}
+          @validationId={{join-with-dash @validationId newIndex}}
+        />
+      {{/let}}
     {{/each}}
   </:content>
 </CustomAccordion>

--- a/app/components/copy-to-clipboard.hbs
+++ b/app/components/copy-to-clipboard.hbs
@@ -1,9 +1,14 @@
-<p
-  id="url"
-  class="au-c-link truncate-url au-u-margin-tiny au-u-margin-left-none"
->
-  {{@value}}
-</p>
+{{#unless @hideValue}}
+  <p
+    id="url"
+    class="au-c-link truncate-url au-u-margin-tiny au-u-margin-left-none"
+  >
+    {{@value}}
+  </p>
+{{/unless}}
 <button type="button" {{on "click" this.handleClick}}>
-  <AuIcon @icon="copy" class="au-c-icon au-c-icon--small au-c-icon--primary" />
+  <AuIcon
+    @icon="{{if @icon @icon 'copy'}}"
+    class="au-c-icon au-c-icon--small au-c-icon--primary"
+  />
 </button>

--- a/app/components/copy-to-clipboard.ts
+++ b/app/components/copy-to-clipboard.ts
@@ -7,7 +7,13 @@ interface ArgsInterface {
 }
 
 interface ToasterService {
-  success(message: string): void;
+  success(message: string, title: string, options?: ToastOptions): void;
+}
+interface ToastOptions {
+  type?: 'info' | 'success' | 'warning' | 'error';
+  icon?: string;
+  timeOut?: number;
+  closable?: boolean;
 }
 
 export default class CopyToClipboard extends Component<ArgsInterface> {
@@ -27,6 +33,8 @@ export default class CopyToClipboard extends Component<ArgsInterface> {
 
   @action
   onSuccess() {
-    this.toaster.success('Gecopieerd naar klembord');
+    this.toaster.success('Gekopieerd naar klembord', '', {
+      timeOut: 2000,
+    });
   }
 }

--- a/app/components/custom-accordion.ts
+++ b/app/components/custom-accordion.ts
@@ -13,6 +13,7 @@ interface ArgsInterface {
 
 export default class SubjectProperty extends Component<ArgsInterface> {
   // AUAccordion settings
+  @tracked isOpen = this.args.defaultOpen ?? false;
 
   get reverse() {
     if (this.args.reverse) return 'au-c-accordion--reverse';
@@ -23,12 +24,6 @@ export default class SubjectProperty extends Component<ArgsInterface> {
   toggleAccordion() {
     this.isOpen = !this.isOpen;
   }
-
-  get defaultOpen() {
-    return this.args.defaultOpen ?? false;
-  }
-
-  @tracked isOpen = this.defaultOpen;
 
   get loading() {
     if (this.args.loading) return 'is-loading';

--- a/app/components/recursive-entry.hbs
+++ b/app/components/recursive-entry.hbs
@@ -1,10 +1,22 @@
 <AuAlert class="au-c-alert--neutral">
-  <CustomAccordion>
+  <CustomAccordion
+    id="validationBlock-{{@validationId}}"
+    @defaultOpen={{if (current-url-hash @validationId) true false}}
+  >
     <:toolbar>
       <span class="au-u-flex--vertical-center au-u-flex">
         <p
           class="truncate-url au-u-h4 au-u-margin-tiny au-u-margin-top-none au-u-margin-left-none au-u-margin-bottom-none"
         >
+          <CopyToClipboard
+            @hideValue="true"
+            @icon="paperclip"
+            @value="{{concat
+              (current-url-without-hash)
+              '#validationBlock-'
+              @validationId
+            }}"
+          />
           {{@subject.className}}
           {{this.displayIndex}}
         </p>
@@ -45,7 +57,9 @@
 
         {{#each @subject.sparqlValidationResults as |sparqlValidationResult|}}
           <AuAlert @skin="warning">
-            <section class="au-u-1-1 accordion-title au-u-flex au-u-flex--between">
+            <section
+              class="au-u-1-1 accordion-title au-u-flex au-u-flex--between"
+            >
               <ul>
                 <li>{{sparqlValidationResult.resultMessage}}</li>
                 <li>Eigenschap: {{sparqlValidationResult.resultPath}}</li>
@@ -55,8 +69,11 @@
           </AuAlert>
         {{/each}}
 
-        {{#each @subject.properties as |property|}}
-          <SubjectProperty @property={{property}} />
+        {{#each @subject.properties as |property index|}}
+          <SubjectProperty
+            @property={{property}}
+            @validationId={{join-with-dash @validationId index}}
+          />
         {{/each}}
       {{/if}}
     </:content>

--- a/app/components/recursive-entry.hbs
+++ b/app/components/recursive-entry.hbs
@@ -70,10 +70,12 @@
         {{/each}}
 
         {{#each @subject.properties as |property index|}}
-          <SubjectProperty
-            @property={{property}}
-            @validationId={{join-with-dash @validationId index}}
-          />
+          {{#let (add index 1) as |newIndex|}}
+            <SubjectProperty
+              @property={{property}}
+              @validationId={{join-with-dash @validationId newIndex}}
+            />
+          {{/let}}
         {{/each}}
       {{/if}}
     </:content>

--- a/app/components/recursive-entry.ts
+++ b/app/components/recursive-entry.ts
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
+import type DocumentService from 'frontend-validation-tool/services/document';
 
 interface ArgsInterface {
   index: number;
@@ -26,8 +27,7 @@ interface ValidationResult {
 }
 
 export default class RecursiveEntry extends Component<ArgsInterface> {
-  @service document;
-
+  @service declare document: DocumentService;
   get skin() {
     const { validCount, totalCount } = this.args.subject;
     return validCount !== undefined

--- a/app/components/root-subject.hbs
+++ b/app/components/root-subject.hbs
@@ -1,7 +1,22 @@
-<CustomAccordion data-test-root-subject @defaultOpen="true">
+<CustomAccordion
+  data-test-root-subject
+  @defaultOpen={{if (current-url-hash @validationId) true false}}
+  id="validationBlock-{{@validationId}}"
+>
   <:toolbar>
     <span class="au-u-flex--vertical-center au-u-flex">
-      <p class="au-u-margin-tiny au-u-margin-left-none au-u-margin-bottom-none">
+      <p
+        class="au-u-margin-right-tiny au-u-margin-left-none au-u-margin-bottom-none"
+      >
+        <CopyToClipboard
+          @hideValue="true"
+          @icon="paperclip"
+          @value="{{concat
+            (current-url-without-hash)
+            '#validationBlock-'
+            @validationId
+          }}"
+        />
         {{@subject.className}}
       </p>
       <StatusPill @subject={{@subject}} />
@@ -22,8 +37,11 @@
     {{#if this.loading}}
       <AuLoader data-test-accordion-loader />
     {{else}}
-      {{#each @subject.properties as |property|}}
-        <SubjectProperty @property={{property}} />
+      {{#each @subject.properties as |property index|}}
+        <SubjectProperty
+          @property={{property}}
+          @validationId={{join-with-dash @validationId index}}
+        />
       {{/each}}
     {{/if}}
   </:content>

--- a/app/components/root-subject.hbs
+++ b/app/components/root-subject.hbs
@@ -38,10 +38,12 @@
       <AuLoader data-test-accordion-loader />
     {{else}}
       {{#each @subject.properties as |property index|}}
-        <SubjectProperty
-          @property={{property}}
-          @validationId={{join-with-dash @validationId index}}
-        />
+        {{#let (add index 1) as |newIndex|}}
+          <SubjectProperty
+            @property={{property}}
+            @validationId={{join-with-dash @validationId newIndex}}
+          />
+        {{/let}}
       {{/each}}
     {{/if}}
   </:content>

--- a/app/components/subject-property.hbs
+++ b/app/components/subject-property.hbs
@@ -83,14 +83,16 @@
         <p>Geen waarde gevonden</p>
       {{else}}
         {{#each @property.value as |value index|}}
-          {{#if value.uri}}
-            <RecursiveEntry
-              @subject={{value}}
-              @validationId={{join-with-dash @validationId index}}
-            />
-          {{else}}
-            <p>{{value}}</p>
-          {{/if}}
+          {{#let (add index 1) as |newIndex|}}
+            {{#if value.uri}}
+              <RecursiveEntry
+                @subject={{value}}
+                @validationId={{join-with-dash @validationId newIndex}}
+              />
+            {{else}}
+              <p>{{value}}</p>
+            {{/if}}
+          {{/let}}
         {{/each}}
       {{/if}}
     </:content>

--- a/app/components/subject-property.hbs
+++ b/app/components/subject-property.hbs
@@ -1,5 +1,8 @@
 <AuAlert data-test-subject-property class="au-c-alert--neutral">
-  <CustomAccordion @defaultOpen="true">
+  <CustomAccordion
+    @defaultOpen={{if (current-url-hash @validationId) true false}}
+    id="validationBlock-{{@validationId}}"
+  >
     <:toolbar>
       <span class="au-u-para-tiny au-u-flex--vertical-center au-u-flex">
         <div class="tooltip">
@@ -7,17 +10,26 @@
             {{! au-u-margin-tiny }}
             class="au-u-h4 au-u-margin-right-tiny au-u-margin-bottom-none au-u-italic"
           >
+            <CopyToClipboard
+              @hideValue="true"
+              @icon="paperclip"
+              @value="{{concat
+                (current-url-without-hash)
+                '#validationBlock-'
+                @validationId
+              }}"
+            />
             {{@property.name}}
           </p>
           {{! <AuIcon @icon="info-circle" class="au-u-margin-right-tiny" /> }}
-          <span class="tooltip-text">De vorm '{{@property.name}}' wordt gebruikt
-            om een huidige of actieve handeling aan te duiden, waarbij één
-            entiteit een andere beïnvloedt.
+          <span class="tooltip-text au-u-padding-small">De vorm '{{@property.name}}'
+            wordt gebruikt om een huidige of actieve handeling aan te duiden,
+            waarbij één entiteit een andere beïnvloedt.
           </span>
         </div>
         <StatusPill @property={{@property}} />
         {{#if @property.maturityLevel}}
-          <AuPill class="au-u-margin-left-tiny" @skin='default'>
+          <AuPill class="au-u-margin-left-tiny" @skin="default">
             {{@property.maturityLevel}}
           </AuPill>
         {{/if}}
@@ -55,22 +67,27 @@
     </:toolbar>
     <:counts>{{this.countText}}</:counts>
     <:content>
-    {{#each @property.sparqlValidationResults as |sparqlValidationResult|}}
-      <AuAlert @skin="warning">
-        <section class="au-u-1-1 accordion-title au-u-flex au-u-flex--between">
-          <ul>
-            <li>{{sparqlValidationResult.resultMessage}}</li>
-            <li>Waarde: {{sparqlValidationResult.value}}</li>
-          </ul>
-        </section>
-      </AuAlert>
+      {{#each @property.sparqlValidationResults as |sparqlValidationResult|}}
+        <AuAlert @skin="warning">
+          <section
+            class="au-u-1-1 accordion-title au-u-flex au-u-flex--between"
+          >
+            <ul>
+              <li>{{sparqlValidationResult.resultMessage}}</li>
+              <li>Waarde: {{sparqlValidationResult.value}}</li>
+            </ul>
+          </section>
+        </AuAlert>
       {{/each}}
       {{#if this.hasNoValues}}
         <p>Geen waarde gevonden</p>
       {{else}}
         {{#each @property.value as |value index|}}
           {{#if value.uri}}
-            <RecursiveEntry @subject={{value}} @index={{index}} />
+            <RecursiveEntry
+              @subject={{value}}
+              @validationId={{join-with-dash @validationId index}}
+            />
           {{else}}
             <p>{{value}}</p>
           {{/if}}

--- a/app/controllers/validation-results.ts
+++ b/app/controllers/validation-results.ts
@@ -29,19 +29,15 @@ export default class ValidationResultsController extends Controller {
 
   @action
   scrollToTarget() {
-    console.log('scrolling');
     const fragment = window.location.hash.slice(1);
     if (!fragment) {
-      console.log('No fragment found in URL');
       return;
     }
     console.log(fragment);
     const offset = 50;
     const observer = new MutationObserver(() => {
       const childElement = document.getElementById(fragment);
-      console.log(childElement);
       if (childElement) {
-        console.log('Element found. Scrolling to target...');
         const rect = childElement.getBoundingClientRect();
         window.scrollTo({
           top: window.scrollY + rect.top - offset,

--- a/app/controllers/validation-results.ts
+++ b/app/controllers/validation-results.ts
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 import { tracked } from 'tracked-built-ins';
 import type DocumentService from 'frontend-validation-tool/services/document';
 import { STATUS_PILL_TYPES } from 'frontend-validation-tool/constants/status-pills';
+import { action } from '@ember/object';
 
 export default class ValidationResultsController extends Controller {
   @service declare document: DocumentService;
@@ -24,5 +25,34 @@ export default class ValidationResultsController extends Controller {
     return this.model?.validatedPublication.isFinished
       ? this.model?.validatedPublication.value
       : [];
+  }
+
+  @action
+  scrollToTarget() {
+    console.log('scrolling');
+    const fragment = window.location.hash.slice(1);
+    if (!fragment) {
+      console.log('No fragment found in URL');
+      return;
+    }
+    console.log(fragment);
+    const offset = 50;
+    const observer = new MutationObserver(() => {
+      const childElement = document.getElementById(fragment);
+      console.log(childElement);
+      if (childElement) {
+        console.log('Element found. Scrolling to target...');
+        const rect = childElement.getBoundingClientRect();
+        window.scrollTo({
+          top: window.scrollY + rect.top - offset,
+          behavior: 'auto',
+        });
+        observer.disconnect();
+      } else {
+        console.log('Element not found. ' + fragment);
+      }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
   }
 }

--- a/app/controllers/validation-results.ts
+++ b/app/controllers/validation-results.ts
@@ -34,20 +34,29 @@ export default class ValidationResultsController extends Controller {
       return;
     }
     const offset = 50;
-    const observer = new MutationObserver(() => {
-      const childElement = document.getElementById(fragment);
-      if (childElement) {
-        const rect = childElement.getBoundingClientRect();
-        window.scrollTo({
-          top: window.scrollY + rect.top - offset,
-          behavior: 'auto',
-        });
-        observer.disconnect();
-      } else {
-        console.log('Element not found. ' + fragment);
-      }
-    });
+    const element = document.getElementById(fragment);
+    if (element) {
+      const rect = element.getBoundingClientRect();
+      window.scrollTo({
+        top: window.scrollY + rect.top - offset,
+        behavior: 'auto',
+      });
+    } else {
+      const observer = new MutationObserver(() => {
+        const element = document.getElementById(fragment);
+        if (element) {
+          const rect = element.getBoundingClientRect();
+          window.scrollTo({
+            top: window.scrollY + rect.top - offset,
+            behavior: 'auto',
+          });
+          observer.disconnect();
+        } else {
+          console.log('Element not found. ' + fragment);
+        }
+      });
 
-    observer.observe(document.body, { childList: true, subtree: true });
+      observer.observe(document.body, { childList: true, subtree: true });
+    }
   }
 }

--- a/app/controllers/validation-results.ts
+++ b/app/controllers/validation-results.ts
@@ -33,7 +33,6 @@ export default class ValidationResultsController extends Controller {
     if (!fragment) {
       return;
     }
-    console.log(fragment);
     const offset = 50;
     const observer = new MutationObserver(() => {
       const childElement = document.getElementById(fragment);

--- a/app/helpers/current-url-hash.ts
+++ b/app/helpers/current-url-hash.ts
@@ -1,0 +1,16 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function currentUrlHash([validationId]: [
+  string,
+  string,
+]) {
+  const hash = window.location.href.split('#')[1];
+  if (hash && validationId) {
+    const parts = hash.split('-');
+    const id = validationId.toString().split('-')[0];
+    if (parts[1] === id) {
+      return true;
+    }
+  }
+  return false;
+});

--- a/app/helpers/current-url-hash.ts
+++ b/app/helpers/current-url-hash.ts
@@ -1,16 +1,21 @@
 import { helper } from '@ember/component/helper';
 
-export default helper(function currentUrlHash([validationId]: [
-  string,
-  string,
-]) {
+export default helper(function currentUrlHash([validationId]: [string]) {
   const hash = window.location.href.split('#')[1];
-  if (hash && validationId) {
-    const parts = hash.split('-');
-    const id = validationId.toString().split('-')[0];
-    if (parts[1] === id) {
-      return true;
-    }
+
+  if (!hash || !validationId) {
+    return false;
   }
-  return false;
+
+  const [, parentIdHash, childIdHash] = hash.split('-');
+  const [parentId, childId] = validationId.toString().split('-');
+  if (parentId && parentId.toString() !== parentIdHash) {
+    return false;
+  }
+
+  if (childId) {
+    return childId.toString() === childIdHash;
+  }
+
+  return true;
 });

--- a/app/helpers/current-url-without-hash.ts
+++ b/app/helpers/current-url-without-hash.ts
@@ -1,0 +1,5 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function currentUrlWithoutHash(positional /*, named*/) {
+  return window.location.href.split('#')[0];
+});

--- a/app/helpers/current-url-without-hash.ts
+++ b/app/helpers/current-url-without-hash.ts
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
 
-export default helper(function currentUrlWithoutHash(positional /*, named*/) {
+export default helper(function currentUrlWithoutHash() {
   return window.location.href.split('#')[0];
 });

--- a/app/helpers/join-with-dash.ts
+++ b/app/helpers/join-with-dash.ts
@@ -1,0 +1,5 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function joinWithDash([val1, val2]) {
+  return `${val1}-${val2}`;
+});

--- a/app/templates/validation-results.hbs
+++ b/app/templates/validation-results.hbs
@@ -68,17 +68,19 @@
         class="entry-container au-u-flex au-u-flex--column au-u-flex--center au-u-1-1"
       >
         {{#each this.validatedPublication.classes as |collection index|}}
-          {{#if (eq (get collection "count") 1)}}
-            <RootSubject
-              @subject={{get collection.objects 0}}
-              @validationId={{index}}
-            />
-          {{else}}
-            <ClassCollection
-              @collection={{collection}}
-              @validationId={{index}}
-            />
-          {{/if}}
+          {{#let (add index 1) as |newIndex|}}
+            {{#if (eq (get collection "count") 1)}}
+              <RootSubject
+                @subject={{get collection.objects 0}}
+                @validationId={{newIndex}}
+              />
+            {{else}}
+              <ClassCollection
+                @collection={{collection}}
+                @validationId={{newIndex}}
+              />
+            {{/if}}
+          {{/let}}
         {{/each}}
       </div>
     {{/if}}

--- a/app/templates/validation-results.hbs
+++ b/app/templates/validation-results.hbs
@@ -56,23 +56,31 @@
       </section>
     </div>
   </div>
-
-  {{! Validation Results }}
-  {{#if this.isLoading}}
-    <AuLoader @centered={{true}}>
-      {{this.document.loadingStatus}}
-    </AuLoader>
-  {{else}}
-    <div
-      class="entry-container au-u-flex au-u-flex--column au-u-flex--center au-u-1-1"
-    >
-      {{#each this.validatedPublication.classes as |collection|}}
-        {{#if (eq (get collection "count") 1)}}
-          <RootSubject @subject={{get collection.objects 0}} />
-        {{else}}
-          <ClassCollection @collection={{collection}} />
-        {{/if}}
-      {{/each}}
-    </div>
-  {{/if}}
+  <div class="au-u-margin-top-large">
+    {{! Validation Results }}
+    {{#if this.isLoading}}
+      <AuLoader @centered={{true}}>
+        {{this.document.loadingStatus}}
+      </AuLoader>
+    {{else}}
+      <div
+        {{did-insert this.scrollToTarget}}
+        class="entry-container au-u-flex au-u-flex--column au-u-flex--center au-u-1-1"
+      >
+        {{#each this.validatedPublication.classes as |collection index|}}
+          {{#if (eq (get collection "count") 1)}}
+            <RootSubject
+              @subject={{get collection.objects 0}}
+              @validationId={{index}}
+            />
+          {{else}}
+            <ClassCollection
+              @collection={{collection}}
+              @validationId={{index}}
+            />
+          {{/if}}
+        {{/each}}
+      </div>
+    {{/if}}
+  </div>
 </section>


### PR DESCRIPTION
As a user of the validation tool,
I want to be able to share a link that directly scrolls to a specific validation block,
so that I can easily point others to specific validation errors.

Acceptance Criteria:

Default Behavior:

Given: A user opens the validation tool without any URL ID,

When: They load the tool,

Then: The page loads as normal without any auto-scroll behavior.

Auto-Scroll Functionality:

Given: A user opens the validation tool with a valid ID in the URL (e.g., #validationBlock123),

When: The tool initializes,

Then: The page automatically scrolls smoothly to the block with the matching id.

Invalid ID Handling:

Given: A user opens the validation tool with an invalid or non-existent ID in the URL (e.g., #nonexistentBlock),

When: The tool initializes,

Then: No scrolling occurs, and the tool loads as normal without breaking functionality.

ID Assignment:

Given: A new validation block is added to the tool,

When: The tool renders the block,

Then: The block is automatically assigned a unique id (e.g., validationBlock123).

And: The id attribute is used exclusively for scroll functionality and has no other functional impact on the tool.

